### PR TITLE
feat!: GetRecommend now returns []Score with X-API-Version: 2

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,15 +56,9 @@ func (c *GorseClient) DeleteFeedbacks(ctx context.Context, userId, itemId string
 	return request[RowAffected, any](ctx, c, "DELETE", c.entryPoint+fmt.Sprintf("/api/feedback/%s/%s", userId, itemId), nil)
 }
 
-// GetRecommend returns recommended items for a user.
-// Deprecated: Use GetRecommendWithScores instead to get recommendation scores.
-func (c *GorseClient) GetRecommend(ctx context.Context, userId string, category string, n, offset int) ([]string, error) {
-	return request[[]string, any](ctx, c, "GET", c.entryPoint+fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset), nil)
-}
-
-// GetRecommendWithScores returns recommended items with scores for a user.
-// This uses X-API-Version: 2 header to get scores.
-func (c *GorseClient) GetRecommendWithScores(ctx context.Context, userId string, category string, n, offset int) ([]Score, error) {
+// GetRecommend returns recommended items with scores for a user.
+// Uses X-API-Version: 2 header to return scores.
+func (c *GorseClient) GetRecommend(ctx context.Context, userId string, category string, n, offset int) ([]Score, error) {
 	url := c.entryPoint + fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset)
 	return requestWithHeaders[[]Score, any](ctx, c, "GET", url, nil, map[string]string{"X-API-Version": "2"})
 }
@@ -98,12 +92,6 @@ func (c *GorseClient) GetCollaborativeFiltering(ctx context.Context, userId stri
 		path += fmt.Sprintf("&category=%s", category)
 	}
 	return request[[]Score, any](ctx, c, "GET", c.entryPoint+path, nil)
-}
-
-// GetRecommendOffSet returns recommended items for a user with offset.
-// Deprecated: Use GetRecommendWithScores instead to get recommendation scores.
-func (c *GorseClient) GetRecommendOffSet(ctx context.Context, userId string, category string, n, offset int) ([]string, error) {
-	return request[[]string, any](ctx, c, "GET", c.entryPoint+fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset), nil)
 }
 
 func (c *GorseClient) SessionRecommend(ctx context.Context, feedbacks []Feedback, n int) ([]Score, error) {

--- a/client.go
+++ b/client.go
@@ -56,8 +56,17 @@ func (c *GorseClient) DeleteFeedbacks(ctx context.Context, userId, itemId string
 	return request[RowAffected, any](ctx, c, "DELETE", c.entryPoint+fmt.Sprintf("/api/feedback/%s/%s", userId, itemId), nil)
 }
 
+// GetRecommend returns recommended items for a user.
+// Deprecated: Use GetRecommendWithScores instead to get recommendation scores.
 func (c *GorseClient) GetRecommend(ctx context.Context, userId string, category string, n, offset int) ([]string, error) {
 	return request[[]string, any](ctx, c, "GET", c.entryPoint+fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset), nil)
+}
+
+// GetRecommendWithScores returns recommended items with scores for a user.
+// This uses X-API-Version: 2 header to get scores.
+func (c *GorseClient) GetRecommendWithScores(ctx context.Context, userId string, category string, n, offset int) ([]Score, error) {
+	url := c.entryPoint + fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset)
+	return requestWithHeaders[[]Score, any](ctx, c, "GET", url, nil, map[string]string{"X-API-Version": "2"})
 }
 
 // use category as empty string to get all elements
@@ -91,9 +100,12 @@ func (c *GorseClient) GetCollaborativeFiltering(ctx context.Context, userId stri
 	return request[[]Score, any](ctx, c, "GET", c.entryPoint+path, nil)
 }
 
+// GetRecommendOffSet returns recommended items for a user with offset.
+// Deprecated: Use GetRecommendWithScores instead to get recommendation scores.
 func (c *GorseClient) GetRecommendOffSet(ctx context.Context, userId string, category string, n, offset int) ([]string, error) {
 	return request[[]string, any](ctx, c, "GET", c.entryPoint+fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset), nil)
 }
+
 func (c *GorseClient) SessionRecommend(ctx context.Context, feedbacks []Feedback, n int) ([]Score, error) {
 	return request[[]Score](ctx, c, "POST", c.entryPoint+fmt.Sprintf("/api/session/recommend?n=%d", n), feedbacks)
 }
@@ -119,7 +131,7 @@ func (c *GorseClient) InsertUsers(ctx context.Context, user []User) (RowAffected
 }
 
 func (c *GorseClient) UpdateUser(ctx context.Context, userId string, user UserPatch) (RowAffected, error) {
-	return request[RowAffected](ctx, c, "PATCH", fmt.Sprintf("%s/api/user/%s", c.entryPoint, userId), user)
+	return request[RowAffected, any](ctx, c, "PATCH", fmt.Sprintf("%s/api/user/%s", c.entryPoint, userId), user)
 }
 
 func (c *GorseClient) GetUser(ctx context.Context, userId string) (User, error) {
@@ -146,7 +158,7 @@ func (c *GorseClient) InsertItems(ctx context.Context, items []Item) (RowAffecte
 
 func (c *GorseClient) UpdateItem(ctx context.Context, itemId string, item ItemPatch) (RowAffected, error) {
 
-	return request[RowAffected](ctx, c, "PATCH", fmt.Sprintf("%s/api/item/%s", c.entryPoint, itemId), item)
+	return request[RowAffected, any](ctx, c, "PATCH", fmt.Sprintf("%s/api/item/%s", c.entryPoint, itemId), item)
 }
 
 func (c *GorseClient) GetItem(ctx context.Context, itemId string) (Item, error) {
@@ -162,6 +174,10 @@ func (c *GorseClient) DeleteItem(ctx context.Context, itemId string) (RowAffecte
 }
 
 func request[Response any, Body any](ctx context.Context, c *GorseClient, method, url string, body Body) (result Response, err error) {
+	return requestWithHeaders[Response, Body](ctx, c, method, url, body, nil)
+}
+
+func requestWithHeaders[Response any, Body any](ctx context.Context, c *GorseClient, method, url string, body Body, headers map[string]string) (result Response, err error) {
 	bodyByte, marshalErr := json.Marshal(body)
 	if marshalErr != nil {
 		return result, marshalErr
@@ -173,6 +189,9 @@ func request[Response any, Body any](ctx context.Context, c *GorseClient, method
 	}
 	req.Header.Set("X-API-Key", c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return result, err

--- a/client_test.go
+++ b/client_test.go
@@ -233,9 +233,9 @@ func (suite *GorseClientTestSuite) TestRecommend() {
 	suite.NoError(err)
 	suite.Len(recommendations, 3)
 	if suite.Len(recommendations, 3) {
-		suite.Equal("315", recommendations[0])
-		suite.Equal("1432", recommendations[1])
-		suite.Equal("918", recommendations[2])
+		suite.Equal("315", recommendations[0].Id)
+		suite.Equal("1432", recommendations[1].Id)
+		suite.Equal("918", recommendations[2].Id)
 	}
 }
 


### PR DESCRIPTION
BREAKING CHANGE: GetRecommend now returns []Score instead of []string

- Uses X-API-Version: 2 header to return recommendation scores
- Removed old GetRecommend that returned []string
- Related: https://github.com/gorse-io/gorse/pull/1140