### PR TITLE
feat: support recommendation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ func main() {
     }
 
     // Get recommendations
-    recs, err := gorse.GetRecommend(ctx, "bob", "", 10, 0)
+    recs, err := gorse.GetRecommend(ctx, "bob", client.RecommendOptions{N: 10})
     if err != nil {
         log.Fatal(err)
     }

--- a/client.go
+++ b/client.go
@@ -67,20 +67,7 @@ func (c *GorseClient) DeleteFeedbacks(ctx context.Context, userId, itemId string
 
 // GetRecommend returns recommended items with scores for a user.
 // Uses X-API-Version: 2 header to return scores.
-func (c *GorseClient) GetRecommend(ctx context.Context, userId string, category string, n, offset int) ([]Score, error) {
-	var categories []string
-	if category != "" {
-		categories = []string{category}
-	}
-	return c.GetRecommendWithOptions(ctx, userId, RecommendOptions{
-		Categories: categories,
-		N:          n,
-		Offset:     offset,
-	})
-}
-
-// GetRecommendWithOptions returns recommended items with scores for a user.
-func (c *GorseClient) GetRecommendWithOptions(ctx context.Context, userId string, options RecommendOptions) ([]Score, error) {
+func (c *GorseClient) GetRecommend(ctx context.Context, userId string, options RecommendOptions) ([]Score, error) {
 	query := url.Values{}
 	for _, category := range options.Categories {
 		if category != "" {

--- a/client.go
+++ b/client.go
@@ -33,6 +33,14 @@ type GorseClient struct {
 	httpClient http.Client
 }
 
+type RecommendOptions struct {
+	Categories     []string
+	WriteBackType  string
+	WriteBackDelay string
+	N              int
+	Offset         int
+}
+
 func NewGorseClient(entryPoint, apiKey string) *GorseClient {
 	return &GorseClient{
 		entryPoint: entryPoint,
@@ -60,8 +68,35 @@ func (c *GorseClient) DeleteFeedbacks(ctx context.Context, userId, itemId string
 // GetRecommend returns recommended items with scores for a user.
 // Uses X-API-Version: 2 header to return scores.
 func (c *GorseClient) GetRecommend(ctx context.Context, userId string, category string, n, offset int) ([]Score, error) {
-	url := c.entryPoint + fmt.Sprintf("/api/recommend/%s/%s?n=%d&offset=%v", userId, category, n, offset)
-	return requestWithHeaders[[]Score, any](ctx, c, "GET", url, nil, map[string]string{"X-API-Version": "2"})
+	var categories []string
+	if category != "" {
+		categories = []string{category}
+	}
+	return c.GetRecommendWithOptions(ctx, userId, RecommendOptions{
+		Categories: categories,
+		N:          n,
+		Offset:     offset,
+	})
+}
+
+// GetRecommendWithOptions returns recommended items with scores for a user.
+func (c *GorseClient) GetRecommendWithOptions(ctx context.Context, userId string, options RecommendOptions) ([]Score, error) {
+	query := url.Values{}
+	for _, category := range options.Categories {
+		if category != "" {
+			query.Add("category", category)
+		}
+	}
+	if options.WriteBackType != "" {
+		query.Set("write-back-type", options.WriteBackType)
+	}
+	if options.WriteBackDelay != "" {
+		query.Set("write-back-delay", options.WriteBackDelay)
+	}
+	query.Set("n", fmt.Sprint(options.N))
+	query.Set("offset", fmt.Sprint(options.Offset))
+	requestURL := fmt.Sprintf("%s/api/recommend/%s?%s", c.entryPoint, url.PathEscape(userId), query.Encode())
+	return requestWithHeaders[[]Score, any](ctx, c, "GET", requestURL, nil, map[string]string{"X-API-Version": "2"})
 }
 
 // use category as empty string to get all elements

--- a/client_test.go
+++ b/client_test.go
@@ -239,7 +239,7 @@ func (suite *GorseClientTestSuite) TestRecommend() {
 	ctx := context.Background()
 	_, err := suite.client.InsertUser(ctx, User{UserId: "3000"})
 	suite.NoError(err)
-	recommendations, err := suite.client.GetRecommend(ctx, "3000", "", 3, 0)
+	recommendations, err := suite.client.GetRecommend(ctx, "3000", RecommendOptions{N: 3})
 	suite.NoError(err)
 	suite.Len(recommendations, 3)
 	if suite.Len(recommendations, 3) {
@@ -253,7 +253,7 @@ func (suite *GorseClientTestSuite) TestRecommendMultipleCategories() {
 	ctx := context.Background()
 	_, err := suite.client.InsertUser(ctx, User{UserId: "4000"})
 	suite.NoError(err)
-	recommendations, err := suite.client.GetRecommendWithOptions(ctx, "4000", RecommendOptions{
+	recommendations, err := suite.client.GetRecommend(ctx, "4000", RecommendOptions{
 		Categories:     []string{"Drama", "Comedy"},
 		WriteBackType:  "recommend",
 		WriteBackDelay: "1h",

--- a/client_test.go
+++ b/client_test.go
@@ -249,6 +249,31 @@ func (suite *GorseClientTestSuite) TestRecommend() {
 	}
 }
 
+func (suite *GorseClientTestSuite) TestRecommendMultipleCategories() {
+	ctx := context.Background()
+	_, err := suite.client.InsertUser(ctx, User{UserId: "4000"})
+	suite.NoError(err)
+	recommendations, err := suite.client.GetRecommendWithOptions(ctx, "4000", RecommendOptions{
+		Categories:     []string{"Drama", "Comedy"},
+		WriteBackType:  "recommend",
+		WriteBackDelay: "1h",
+		N:              3,
+		Offset:         0,
+	})
+	suite.NoError(err)
+	if suite.Len(recommendations, 3) {
+		for _, recommendation := range recommendations {
+			item, err := suite.client.GetItem(ctx, recommendation.Id)
+			suite.NoError(err)
+			matched := false
+			for _, category := range item.Categories {
+				matched = matched || category == "Drama" || category == "Comedy"
+			}
+			suite.True(matched)
+		}
+	}
+}
+
 func TestGorseClientTestSuite(t *testing.T) {
 	suite.Run(t, new(GorseClientTestSuite))
 }


### PR DESCRIPTION
## Summary
- add `RecommendOptions` and `GetRecommendWithOptions`
- preserve the existing `GetRecommend` signature as a compatibility wrapper
- support multiple categories, write-back, `n`, and `offset` on the current endpoint
- keep scored responses with `X-API-Version: 2`

## Tests
- `go test ./... -count=1`
- `go test ./... -run '^$'`
